### PR TITLE
Test용 signInTest mutation 추가

### DIFF
--- a/resolvers/user.js
+++ b/resolvers/user.js
@@ -1,7 +1,7 @@
 const User = require('../models/user');
 const axios = require('axios');
 const { ApolloError } = require('apollo-server-express');
-const { signToken } = require('../utils');
+const { signToken, verifyToken } = require('../utils');
 
 const googleApi = 'https://www.googleapis.com/oauth2/v1/userinfo';
 
@@ -49,6 +49,21 @@ const userResolvers = {
         }
       } catch (error) { throw error; }
       return;
+    },
+
+    async signInTest (_, args) {
+      const { token } = args;
+      try {
+        const data = verifyToken(token);
+        const { userId } = data;
+        if (!userId) { return null; }
+
+        const user = await User.findById(userId);
+        return {
+          user,
+          token: signToken({ userId: user._id }),
+        };
+      } catch (error) { throw error; }
     },
 
     async signUp (_, args) {

--- a/schema/user.js
+++ b/schema/user.js
@@ -21,6 +21,7 @@ const userTypeDefs = gql`
 
   type Mutation {
     signIn (accessToken: String!, provider: String): Auth
+    signInTest (token: String!): Auth
     signUp (accessToken: String!, provider: String): User
     withdraw (id: ID!): Boolean
   }


### PR DESCRIPTION
## 🛠 주요 변경 사항 
테스트할 때 사용할 토큰 발급이 이전보다 쉽게끔 `signInTest` mutation을 추가했습니다.
`token` field에 공용 문서에 있는 토큰 값을 넣어 mutation을 날리면, 테스트 시 사용할 수 있는 토큰값과 계정 정보가 반환됩니다.
해당 계정은 archive google 계정으로 저희 프로젝트에 회원가입한 계정입니다. 

<img width="262" alt="스크린샷 2023-08-04 오후 5 13 55" src="https://github.com/anniversaryArchive/archive-back/assets/31975198/55e8c318-ee4e-42d2-925b-1edf4a08503c">