### PR TITLE
Favorite 관련 Schema, Query 수정 

### DIFF
--- a/common/date.js
+++ b/common/date.js
@@ -1,0 +1,8 @@
+exports.initDate = function (date) {
+  date = new Date(date);
+  date.setHours(0);
+  date.setMinutes(0);
+  date.setSeconds(0);
+  date.setDate(date.getDate() + 1);
+  return date;
+}

--- a/models/favorite.js
+++ b/models/favorite.js
@@ -3,9 +3,9 @@ const mongoose = require('mongoose');
 const favoriteSchema = new mongoose.Schema({
   user: { type: mongoose.Types.ObjectId, required: true },    // 즐겨찾기한 유저
   group: { type: mongoose.Types.ObjectId, require: true },    // 즐겨찾기한 카페 그룹
-  archive: { type: mongoose.Types.ObjectId, required: true }, // 즐겨찾기한 카페 
-  createdAt: { type: Date, default: Date.now },               // 생성 일자 
-  updatedAt: { type: Date, default: Date.now },               // 마지막 업데이트 일자 
+  archive: { type: mongoose.Types.ObjectId, required: true, ref: 'archive' }, // 즐겨찾기한 카페
+  createdAt: { type: Date, default: Date.now },               // 생성 일자
+  updatedAt: { type: Date, default: Date.now },               // 마지막 업데이트 일자
 });
 
 module.exports = mongoose.model('favorite', favoriteSchema);

--- a/models/favorite.js
+++ b/models/favorite.js
@@ -2,7 +2,6 @@ const mongoose = require('mongoose');
 
 const favoriteSchema = new mongoose.Schema({
   user: { type: mongoose.Types.ObjectId, required: true },    // 즐겨찾기한 유저
-  group: { type: mongoose.Types.ObjectId, require: true },    // 즐겨찾기한 카페 그룹
   archive: { type: mongoose.Types.ObjectId, required: true, ref: 'archive' }, // 즐겨찾기한 카페
   createdAt: { type: Date, default: Date.now },               // 생성 일자
   updatedAt: { type: Date, default: Date.now },               // 마지막 업데이트 일자

--- a/resolvers/archive.js
+++ b/resolvers/archive.js
@@ -6,20 +6,12 @@ const Favorite = require('../models/favorite')
 const { getFindDoc } = require('../common/pagination');
 const { ApolloError } = require('apollo-server-express');
 const { getUserId } = require('../utils');
+const { initDate } = require('../common/date');
 
 function checkArtistOrGroup ({ artist, group }) {
   if (!artist && !group) {
     throw new ApolloError('Either artist or group must exist.', 1002, {});
   }
-}
-
-function initDate (date) {
-  date = new Date(date);
-  date.setHours(0);
-  date.setMinutes(0);
-  date.setSeconds(0);
-  date.setDate(date.getDate() + 1);
-  return date;
 }
 
 const archiveResolvers = {
@@ -45,7 +37,7 @@ const archiveResolvers = {
     /**
      * Archive를 Pagination으로 가져온다.
      * - page(Int): 현재 페이지 (0부터 시작)
-     * - perPage(Int): 한 페이지에 보여줄 데이터 수 
+     * - perPage(Int): 한 페이지에 보여줄 데이터 수
      * - sortField(String): 데이터 정렬할 필드 이름
      * - sortOrder(Int): 1: 오름차순, -1: 내림차순
      * - filter(FilterOption)
@@ -63,7 +55,7 @@ const archiveResolvers = {
         end = initDate(end);
         doc.startDate = { $lte: end.toISOString() };
       }
-      if (start) { 
+      if (start) {
         start = initDate(start);
         doc.endDate = { $gte: start.toISOString() };
       }

--- a/resolvers/favorite.js
+++ b/resolvers/favorite.js
@@ -28,9 +28,9 @@ const favoriteResolvers = {
      * - perPage(Int): 한 페이지에 보여줄 데이터 수
      * - sortField(String): 데이터 정렬할 필드 이름
      * - sortOrder(Int): 1: 오름차순, -1: 내림차순
-     * - group
-     * - start
-     * - end
+     * - group : archive.group filtering
+     * - start : archive.startDate - endDate filtering
+     * - end : archive.startDate - endDate filtering
      */
     async FavoritePagination (_, args, context) {
       const userId = getUserId(context);

--- a/resolvers/favorite.js
+++ b/resolvers/favorite.js
@@ -32,6 +32,7 @@ const favoriteResolvers = {
       try {
         const skip = args.perPage * page;
         let pipelines = [
+          // archive id 를 이용해 archiveInfo field로 archive 데이터를 가져온다.
           { '$addFields': { 'archiveId': { '$toObjectId': '$archive' } } },
           {
             '$lookup': {
@@ -42,12 +43,16 @@ const favoriteResolvers = {
             }
           },
           { '$unwind': '$archiveInfo' },
+          // 현재 user의 데이터만 가져오도록 filtering
           { '$match': { 'user': ObjectId(userId) } },
         ];
 
+        // group filtering
         if (args.group) {
           pipelines.push({ '$match': { 'archiveInfo.group': ObjectId(args.group) } });
         }
+
+        // start date ~ end date filtering
         if (args.end) {
           pipelines.push({ '$match': { 'archiveInfo.startDate': { '$lte': initDate(args.end) } } });
         }

--- a/resolvers/favorite.js
+++ b/resolvers/favorite.js
@@ -10,15 +10,7 @@ const Archive = require('../models/archive');
 const { ApolloError } = require('apollo-server-express');
 
 const { getUserId } = require('../utils');
-
-function initDate (date) {
-  date = new Date(date);
-  date.setHours(0);
-  date.setMinutes(0);
-  date.setSeconds(0);
-  date.setDate(date.getDate() + 1);
-  return date;
-}
+const { initDate } = require('../common/date');
 
 const favoriteResolvers = {
   Query: {

--- a/resolvers/favorite.js
+++ b/resolvers/favorite.js
@@ -1,3 +1,7 @@
+// 참고
+// https://joyful-development.tistory.com/21
+
+const ObjectId = require('mongodb').ObjectID;
 const Favorite = require('../models/favorite');
 const User = require('../models/user');
 const Group = require('../models/group');
@@ -6,32 +10,72 @@ const Archive = require('../models/archive');
 const { ApolloError } = require('apollo-server-express');
 
 const { getUserId } = require('../utils');
-const { getFindDoc } = require('../common/pagination');
+
+function initDate (date) {
+  date = new Date(date);
+  date.setHours(0);
+  date.setMinutes(0);
+  date.setSeconds(0);
+  date.setDate(date.getDate() + 1);
+  return date;
+}
 
 const favoriteResolvers = {
   Query: {
     /**
      * Favorite을 Pagination으로 가져온다.
      * - page(Int): 현재 페이지 (0부터 시작)
-     * - perPage(Int): 한 페이지에 보여줄 데이터 수 
+     * - perPage(Int): 한 페이지에 보여줄 데이터 수
      * - sortField(String): 데이터 정렬할 필드 이름
      * - sortOrder(Int): 1: 오름차순, -1: 내림차순
-     * - filter(FilterOption)
+     * - group
+     * - start
+     * - end
      */
     async FavoritePagination (_, args, context) {
       const userId = getUserId(context);
       const sortField = args.sortField || 'createdAt';
       const sortOrder = args.sortOrder || 1;
       const page = args.page || 0;
-      const filter = args.filter || {};
-      filter.flds = Object.assign({}, filter.flds, { user: userId });
-      const doc = getFindDoc(filter);
       try {
-        const data = await Favorite.find(doc)
-          .sort({ [sortField]: sortOrder })
-          .limit(args.perPage)
-          .skip(args.perPage * page)
-        const total = await Favorite.find(doc).countDocuments({});
+        const skip = args.perPage * page;
+        let pipelines = [
+          { '$addFields': { 'archiveId': { '$toObjectId': '$archive' } } },
+          {
+            '$lookup': {
+              'from': 'archives',
+              'localField': 'archive',
+              'foreignField': '_id',
+              'as': 'archiveInfo'
+            }
+          },
+          { '$unwind': '$archiveInfo' },
+          { '$match': { 'user': ObjectId(userId) } },
+        ];
+
+        if (args.group) {
+          pipelines.push({ '$match': { 'archiveInfo.group': ObjectId(args.group) } });
+        }
+        if (args.end) {
+          pipelines.push({ '$match': { 'archiveInfo.startDate': { '$lte': initDate(args.end) } } });
+        }
+        if (args.start) {
+          pipelines.push({ '$match': { 'archiveInfo.endDate': { '$gte': initDate(args.start) } } });
+        }
+
+        pipelines = [
+          ...pipelines,
+          { '$sort': { [sortField]: sortOrder } },
+          {
+            '$facet': {
+              data: [{ $skip: skip }, { $limit: args.perPage }],
+              total: [{ $count: 'count' }]
+            }
+          }
+        ];
+
+        const results = await Favorite.aggregate(pipelines);
+        const { data, total } = results[0];
         return { data, total };
       } catch (error) {
         console.log(error);
@@ -82,7 +126,7 @@ const favoriteResolvers = {
         const findFavorite = await Favorite.findOne(doc);
         if (findFavorite) { return findFavorite; }
         const findArchive = await Archive.findOne({ _id: archive });
-        if (!findArchive) { 
+        if (!findArchive) {
           throw new ApolloError('해당 카페(Archive)를 찾을 수가 없습니다.', 1003, {});
         }
         doc.group = findArchive.group;

--- a/schema/favorite.js
+++ b/schema/favorite.js
@@ -2,7 +2,7 @@ const { gql } = require('apollo-server-express');
 
 const favoriteTypeDefs = gql`
   type Query {
-    FavoritePagination (page: Int, perPage: Int, sortField: String, sortOrder: Int, filter: FilterOption): FavoritePage
+    FavoritePagination (page: Int, perPage: Int, sortField: String, sortOrder: Int, group: ID, start: Date, end: Date): FavoritePage
     FavoriteGroupList: [Group]
   }
   type Favorite {
@@ -16,7 +16,7 @@ const favoriteTypeDefs = gql`
     data: [Favorite]
     total: Int!
   }
-  
+
   type Mutation {
     createFavorite (archive: ID!): Favorite
     removeFavorite (id: ID!): Boolean


### PR DESCRIPTION
## 🛠 주요 변경 사항 
1. archive에 있는 데이터인 group을 favorite field로도 이중으로 저장하는 부분을 수정하였습니다.
2. start date ~ end date filtering을 추가하였습니다.

위 작업을 위하여 `.find(...)` 가 아닌 `.aggregate(...)` 을 사용하였습니다 !

⭐️ 프론트에서 확인해야 하는 부분은
`FavoritePagination` query parameter에서 `filter` 필드가 빠지고, `group`, `start`, `end`가 추가됐다는 점입니다!
<img width="1048" alt="스크린샷 2023-08-08 오후 11 24 29" src="https://github.com/anniversaryArchive/archive-back/assets/31975198/e50f09f9-c16c-47cd-9115-1391d1df3ef7">
<img width="999" alt="스크린샷 2023-08-08 오후 11 23 54" src="https://github.com/anniversaryArchive/archive-back/assets/31975198/2dcc3a0a-69da-43ff-a8b1-24752052a7f7">
