### PR TITLE
reomveFavorite mutation 수정

### DIFF
--- a/resolvers/favorite.js
+++ b/resolvers/favorite.js
@@ -147,9 +147,11 @@ const favoriteResolvers = {
         throw error;
       }
     },
-    async removeFavorite (_, args) {
+    async removeFavorite (_, args, context) {
       try {
-        const result = await Favorite.deleteOne({ _id: args.id });
+        const { archive } = args;
+        const user = getUserId(context);
+        const result = await Favorite.deleteOne({ archive, user });
         return result.deletedCount === 1;
       } catch (error) {
         throw error;

--- a/schema/favorite.js
+++ b/schema/favorite.js
@@ -19,7 +19,7 @@ const favoriteTypeDefs = gql`
 
   type Mutation {
     createFavorite (archive: ID!): Favorite
-    removeFavorite (id: ID!): Boolean
+    removeFavorite (archive: ID!): Boolean
   }
 `;
 


### PR DESCRIPTION
## 🛠 주요 변경 사항 
기존 `removeFavorite` mutation은 Favorite._id를 받게끔 되어있었으나, Archive 리스트에서 다른 별도로 데이터를 찾거나 하지 않고, 바로 지울 수 있게끔 `Archive._id` 를 받아오게끔 수정하였습니다.

따라서 `removeFavorite` mutation 시, 현재 `User._id`와 `Archive._id`를 확인하여, Favorite을 삭제합니다.
