### PR TITLE
Pagination Filter 수정 

### DIFF
--- a/common/pagination.js
+++ b/common/pagination.js
@@ -1,18 +1,24 @@
 exports.getFindDoc = function (filter) {
-  if (!filter) { return {}; }
+  if (!filter) {
+    return {};
+  }
   const { fields, q, flds } = filter;
 
   const findDoc = {};
   if (fields && q) {
-    findDoc['$or'] = fields.map((field) => {
+    findDoc["$or"] = fields.map((field) => {
       return { [field]: { $regex: q } };
     });
   }
-  
+
   if (flds) {
     for (const key of Object.keys(flds)) {
-      findDoc[key] = flds[key];
+      if (Array.isArray(flds[key])) {
+        findDoc[key] = { $in: flds[key] };
+      } else {
+        findDoc[key] = flds[key];
+      }
     }
   }
   return findDoc;
-}
+};


### PR DESCRIPTION
## 🛠 주요 변경 사항 
Pagination query에서 사용하는 `filter` 부분을 수정하였습니다. 
`filter.flds` 를 이용해 데이터를 필터링했었는데, string 만 가능했던 것을 array도 가능하게끔 구현하였습니다.

예를 들어 ArchivePagination query를 사용할 때, artist가 `ID1` 이거나 `ID2`인 Archive를 가져오고 싶다면

```
"filter": {
    "flds": {
      "artist": [
        "ID1",
        "ID2"
      ]
    }
  }
```

filter 값을 위와 같이 넘겨주면 됩니다.
